### PR TITLE
Handle Infinity inputs for Chinese numeral conversion

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -72,6 +72,8 @@ describe('toChineseNumeral', () => {
     expect(toChineseNumeral(-10.000001)).toBe('負十點零零零零零一')
     expect(toChineseNumeral(99999.999)).toBe('九萬九千九百九十九點九九九')
     expect(toChineseNumeral(-99999.999)).toBe('負九萬九千九百九十九點九九九')
+    expect(toChineseNumeral(Infinity)).toBe('無限')
+    expect(() => toChineseNumeral(Number.NaN)).toThrow(TypeError)
   })
   test('Extra cases', () => {
     expect(toChineseNumeral(100000)).toBe('十萬')

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,14 @@ const financialNumerals: ChineseNumeralMap = {
 }
 
 const toChineseNumeral = (num: number): string => {
+  if (Number.isNaN(num)) {
+    throw new TypeError('Input must be a finite number')
+  }
+
+  if (!Number.isFinite(num)) {
+    return '無限'
+  }
+
   if (num < 0) {
     return numerals['-'] + toChineseNumeral(-num)
   }


### PR DESCRIPTION
## Summary
- add explicit handling for NaN and Infinity in toChineseNumeral, returning 無限 for non-finite values while preserving the NaN error
- extend the Special Cases test to cover Infinity output and ensure NaN continues to throw

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68df1be2e5d0832a98790f7ca091150e